### PR TITLE
Game refactor

### DIFF
--- a/battleshipz/lib/cell.rb
+++ b/battleshipz/lib/cell.rb
@@ -24,7 +24,7 @@ attr_reader :coordinate, :ship
 
   def fire_upon
     @fired_upon = true
-    if @ship != nil
+    if @ship != nil #!empty?
       @ship.hit
     end
   end
@@ -40,10 +40,20 @@ attr_reader :coordinate, :ship
       "H"
     elsif fired_upon? && empty?
       "M"
-    elsif optional == true && @ship != nil
+    elsif optional == true && @ship != nil #!empty?
       "S"
     else
       "."
+    end
+  end
+
+  def render_word
+    if render == "M"
+     "miss"
+    elsif render == "H"
+      "hit"
+    else
+      "hit"
     end
   end
 

--- a/battleshipz/lib/cell.rb
+++ b/battleshipz/lib/cell.rb
@@ -24,7 +24,7 @@ attr_reader :coordinate, :ship
 
   def fire_upon
     @fired_upon = true
-    if @ship != nil #!empty?
+    if !empty? 
       @ship.hit
     end
   end
@@ -40,7 +40,7 @@ attr_reader :coordinate, :ship
       "H"
     elsif fired_upon? && empty?
       "M"
-    elsif optional == true && @ship != nil #!empty?
+    elsif optional == true && !empty?
       "S"
     else
       "."

--- a/battleshipz/lib/game.rb
+++ b/battleshipz/lib/game.rb
@@ -106,7 +106,7 @@ class Game
       if chosen_cell.fired_upon?
         while chosen_cell.fired_upon?
         puts "Oops, you've aready fired upon this cell."
-        puts "Please select another coordiante:"
+        puts "Please select another coordinate:"
         shot = gets.chomp
         chosen_cell = @computer_board.cells[shot]
         end
@@ -117,10 +117,9 @@ class Game
         random_computer_guess = @human_board.cells.values.sample
       end
       random_computer_guess.fire_upon
-
       puts "Results from this turn are as follows:"
-      puts "Your shot on #{chosen_cell.coordinate} was a #{chosen_cell.render}."
-      puts "My shot on #{random_computer_guess.coordinate} was a #{random_computer_guess.render}."
+      puts "Your shot on #{chosen_cell.coordinate} was a #{chosen_cell.render_word}."
+      puts "My shot on #{random_computer_guess.coordinate} was a #{random_computer_guess.render_word}."
     end
     start
   end


### PR DESCRIPTION
Added Cell#render_word to have "hit" or "miss" be displayed in the turn report instead of "H" or "M". A sunken ship is also reported as "hit". Additionally, refactored Cell#fire_upon and Cell#render to use the method !empty? instead of @ship != nil.